### PR TITLE
fix(mobile): ROI grid, invite heading, footer PIA logo, scroll restore

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -92,11 +92,9 @@ const tp = useTranslatedPath(lang);
   <!-- PIA GROUP BAND -->
   <section class="ix-footer__pia">
     <div class="ix-container ix-footer__piaWrap">
-      <span class="ix-footer__pia-label">{t('footer.pia.prefix')}</span>
       <a href="https://www.pia-group.net/" target="_blank" rel="noopener noreferrer" class="ix-footer__pia-link" aria-label="PiA Group website">
         <img src="/assets/img/Pia.png" alt="PiA Group" class="ix-footer__pia-logo" />
       </a>
-      <span class="ix-footer__pia-label">{t('footer.pia.suffix')}</span>
     </div>
   </section>
 

--- a/src/components/gamification/ROICalculator.astro
+++ b/src/components/gamification/ROICalculator.astro
@@ -609,9 +609,21 @@ const t = STRINGS[lang];
       grid-template-columns: 1fr;
       gap: 32px;
     }
+    .roi-segments {
+      flex-wrap: wrap;
+    }
+    .roi-segment {
+      flex: 0 0 50%;
+    }
+    .roi-segment:nth-child(2n) .roi-segment__label {
+      border-right: none;
+    }
+    .roi-segment:nth-child(-n+2) .roi-segment__label {
+      border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+    }
     .roi-segment__label {
-      padding: 10px 4px;
-      font-size: 0.75rem;
+      padding: 10px 8px;
+      font-size: 0.82rem;
     }
     .roi-metric__value {
       font-size: 1.6rem;

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -92,6 +92,7 @@ const breadcrumbSchema = breadcrumbs.length > 0 ? {
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <script>history.scrollRestoration = 'manual'; window.scrollTo(0, 0);</script>
   <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1" />
   <meta name="author" content="Intellica" />
   <meta name="generator" content={Astro.generator} />

--- a/src/page-templates/AcademyPage.astro
+++ b/src/page-templates/AcademyPage.astro
@@ -293,7 +293,8 @@ const faqSchema = {
 @media (max-width: 1100px) { .hero-stats { justify-content: flex-start; flex-wrap: wrap; gap: 20px; } }
 .invite-card { padding: 80px 40px; border-radius: 48px; }
 .invite-heading { font-size: clamp(1.5rem, 5vw, 2.5rem); margin-inline: auto; text-align: center; line-height: 1.2; }
-@media (max-width: 768px) { .invite-card { padding: 48px 24px; border-radius: 28px; } .invite-heading { font-size: 1.5rem; } }
+@media (max-width: 1100px) { .invite-heading { font-size: 1.6rem !important; padding-right: 0 !important; min-height: auto !important; } }
+@media (max-width: 768px) { .invite-card { padding: 48px 24px; border-radius: 28px; } .invite-heading { font-size: 1.6rem !important; } }
 .luxury-card { transition: all 0.4s; }
 .luxury-card:hover { transform: translateY(-8px); border-color: var(--clr-primary); }
 .curriculum-card { display: flex; flex-direction: column; height: 100%; }


### PR DESCRIPTION
## Summary

- **ROICalculator**: company size butonları mobilde 2×2 grid'e wrap oluyor (taşma düzeltildi)
- **AcademyPage**: invite heading global `!important` override eziyordu, `1.6rem` ile düzeltildi
- **Footer**: PIA logosu yanındaki "A / Company" (TR: "Bir / Şirketi") metinleri kaldırıldı
- **Layout**: `history.scrollRestoration='manual'` eklendi — sayfalar her zaman hero'dan açılıyor

## Test plan
- [ ] `/solutions` ve `/tr/solutions` — Şirket Büyüklüğü 2×2 grid mobilde
- [ ] `/academy` ve `/tr/academy` — invite heading 3 satır, okunabilir boyut
- [ ] Footer PIA bölümü — sadece logo görünüyor
- [ ] BottomNav'dan Academy'ye gidince sayfa hero'dan açılıyor

🤖 Generated with [Claude Code](https://claude.com/claude-code)