### PR TITLE
fix(mobile): ROI calculator TR overflow — select width & grid minmax

### DIFF
--- a/src/components/gamification/ROICalculator.astro
+++ b/src/components/gamification/ROICalculator.astro
@@ -329,6 +329,7 @@ const t = STRINGS[lang];
     grid-template-columns: 1fr 1fr;
     gap: 40px;
     align-items: start;
+    min-width: 0;
   }
 
   /* ── Inputs ── */
@@ -336,6 +337,7 @@ const t = STRINGS[lang];
     display: flex;
     flex-direction: column;
     gap: 28px;
+    min-width: 0;
   }
 
   .roi-field {
@@ -607,7 +609,7 @@ const t = STRINGS[lang];
       padding: 24px 16px;
     }
     .roi-layout {
-      grid-template-columns: 1fr;
+      grid-template-columns: minmax(0, 1fr);
       gap: 32px;
     }
     .roi-segments {

--- a/src/components/gamification/ROICalculator.astro
+++ b/src/components/gamification/ROICalculator.astro
@@ -358,6 +358,7 @@ const t = STRINGS[lang];
 
   /* ── Select ── */
   .roi-select {
+    width: 100%;
     appearance: none;
     -webkit-appearance: none;
     padding: 14px 40px 14px 16px;


### PR DESCRIPTION
## Summary

- `roi-select`: added `width: 100%` to prevent TR option labels from expanding beyond container
- `roi-layout`: changed mobile `grid-template-columns: 1fr` → `minmax(0, 1fr)` to prevent CSS Grid column inflation beyond available space
- `roi-inputs`, `roi-layout`: added `min-width: 0` on grid items

**Root cause:** CSS Grid `1fr` columns respect `min-width: auto` by default, allowing content to inflate column size beyond the grid container. `minmax(0, 1fr)` explicitly caps at available space.

## Test plan
- [ ] `/tr/solutions` mobil — ROI hesaplayıcı kart içeriği viewport içinde
- [ ] `/solutions` EN — aynı şekilde çalışıyor
- [ ] Tüm 3 input alanı (sektör, şirket büyüklüğü, olgunluk) düzgün görünüyor

🤖 Generated with [Claude Code](https://claude.com/claude-code)