### PR TITLE
style(typography): unify card sizes and normalize colors

### DIFF
--- a/src/components/gamification/ROICalculator.astro
+++ b/src/components/gamification/ROICalculator.astro
@@ -97,7 +97,7 @@ const STRINGS = {
     speedLabel: 'Karar Hızı İyileşmesi',
     riskLabel: 'Risk Azalması',
     projectionLabel: '3 Yıllık Projeksiyon ROI',
-    ctaText: 'Verinizin Değerini Açığa Çıkarın',
+    ctaText: 'Veri Değerinizi Keşfedin',
     ctaHref: '/tr/contact',
   },
 } as const;

--- a/src/page-templates/AboutPage.astro
+++ b/src/page-templates/AboutPage.astro
@@ -59,7 +59,7 @@ const aboutSchema = {
           <p style="color:var(--clr-light-muted);font-size:1.15rem;line-height:1.8;margin-bottom:24px;">
             {t('about.whoWeAre.desc1')}
           </p>
-          <p style="color:var(--clr-light-muted);font-size:1.05rem;line-height:1.8;margin-bottom:32px;">
+          <p style="color:var(--clr-light-muted);font-size:1rem;line-height:1.8;margin-bottom:32px;">
             {t('about.whoWeAre.desc2')}
           </p>
 

--- a/src/page-templates/AboutPage.astro
+++ b/src/page-templates/AboutPage.astro
@@ -98,26 +98,26 @@ const aboutSchema = {
         <div>
           <div class="section-label">{t('about.capabilities.label')}</div>
           <h2 style="color:var(--clr-light-text); margin-bottom: 24px;">{t('about.capabilities.title')}<span class="grad-text">{t('about.capabilities.titleHighlight')}</span></h2>
-          <p style="color:var(--clr-light-muted); font-size: 1.1rem; line-height: 1.7;">
+          <p style="color:var(--clr-light-muted); font-size: var(--fs-section-sub); line-height: 1.7;">
             {t('about.capabilities.desc')}
           </p>
         </div>
         <div class="grid-2" style="gap: 20px;">
           <div class="cap-card-modern" style="background: #fff; padding: 24px;">
             <h4 style="margin-bottom: 12px; color: var(--clr-primary);">{t('about.capabilities.card1.title')}</h4>
-             <p style="font-size: 0.9rem; color: var(--clr-light-muted);">{t('about.capabilities.card1.desc')}</p>
+             <p style="font-size: var(--fs-card-body); color: var(--clr-light-muted);">{t('about.capabilities.card1.desc')}</p>
           </div>
           <div class="cap-card-modern" style="background: #fff; padding: 24px;">
             <h4 style="margin-bottom: 12px; color: var(--clr-primary);">{t('about.capabilities.card2.title')}</h4>
-             <p style="font-size: 0.9rem; color: var(--clr-light-muted);">{t('about.capabilities.card2.desc')}</p>
+             <p style="font-size: var(--fs-card-body); color: var(--clr-light-muted);">{t('about.capabilities.card2.desc')}</p>
           </div>
           <div class="cap-card-modern" style="background: #fff; padding: 24px;">
             <h4 style="margin-bottom: 12px; color: var(--clr-primary);">{t('about.capabilities.card3.title')}</h4>
-            <p style="font-size: 0.9rem; color: var(--clr-light-muted);">{t('about.capabilities.card3.desc')}</p>
+            <p style="font-size: var(--fs-card-body); color: var(--clr-light-muted);">{t('about.capabilities.card3.desc')}</p>
           </div>
           <div class="cap-card-modern" style="background: #fff; padding: 24px;">
             <h4 style="margin-bottom: 12px; color: var(--clr-primary);">{t('about.capabilities.card4.title')}</h4>
-            <p style="font-size: 0.9rem; color: var(--clr-light-muted);">{t('about.capabilities.card4.desc')}</p>
+            <p style="font-size: var(--fs-card-body); color: var(--clr-light-muted);">{t('about.capabilities.card4.desc')}</p>
           </div>
         </div>
       </div>
@@ -172,29 +172,29 @@ const aboutSchema = {
           <div class="value-card__icon">
             <img src="/assets/img/intellica_camlogo_icibos.png" alt={t('about.values.card1.imgAlt')} style="width: 40px; height: auto; filter: drop-shadow(0 4px 10px rgba(0,196,204,0.3));" loading="lazy" />
           </div>
-          <h3 style="color:var(--clr-light-text);font-size:1.1rem;margin-bottom:8px;">{t('about.values.card1.title')}</h3>
-           <p style="color:var(--clr-light-muted);font-size:0.88rem;">{t('about.values.card1.desc')}</p>
+          <h3 style="color:var(--clr-light-text);font-size:var(--fs-card-title);font-weight:var(--fw-card-title);margin-bottom:8px;">{t('about.values.card1.title')}</h3>
+           <p style="color:var(--clr-light-muted);font-size:var(--fs-card-body);">{t('about.values.card1.desc')}</p>
         </div>
         <div class="value-card card-light">
           <div class="value-card__icon">
             <img src="/assets/img/intellica_camlogo_icibos.png" alt={t('about.values.card2.imgAlt')} style="width: 40px; height: auto; filter: drop-shadow(0 4px 10px rgba(0,196,204,0.3));" loading="lazy" />
           </div>
-          <h3 style="color:var(--clr-light-text);font-size:1.1rem;margin-bottom:8px;">{t('about.values.card2.title')}</h3>
-           <p style="color:var(--clr-light-muted);font-size:0.88rem;">{t('about.values.card2.desc')}</p>
+          <h3 style="color:var(--clr-light-text);font-size:var(--fs-card-title);font-weight:var(--fw-card-title);margin-bottom:8px;">{t('about.values.card2.title')}</h3>
+           <p style="color:var(--clr-light-muted);font-size:var(--fs-card-body);">{t('about.values.card2.desc')}</p>
         </div>
         <div class="value-card card-light">
           <div class="value-card__icon">
             <img src="/assets/img/intellica_camlogo_icibos.png" alt={t('about.values.card3.imgAlt')} style="width: 40px; height: auto; filter: drop-shadow(0 4px 10px rgba(0,196,204,0.3));" loading="lazy" />
           </div>
-          <h3 style="color:var(--clr-light-text);font-size:1.1rem;margin-bottom:8px;">{t('about.values.card3.title')}</h3>
-           <p style="color:var(--clr-light-muted);font-size:0.88rem;">{t('about.values.card3.desc')}</p>
+          <h3 style="color:var(--clr-light-text);font-size:var(--fs-card-title);font-weight:var(--fw-card-title);margin-bottom:8px;">{t('about.values.card3.title')}</h3>
+           <p style="color:var(--clr-light-muted);font-size:var(--fs-card-body);">{t('about.values.card3.desc')}</p>
         </div>
         <div class="value-card card-light">
           <div class="value-card__icon">
             <img src="/assets/img/intellica_camlogo_icibos.png" alt={t('about.values.card4.imgAlt')} style="width: 40px; height: auto; filter: drop-shadow(0 4px 10px rgba(0,196,204,0.3));" loading="lazy" />
           </div>
-          <h3 style="color:var(--clr-light-text);font-size:1.1rem;margin-bottom:8px;">{t('about.values.card4.title')}</h3>
-           <p style="color:var(--clr-light-muted);font-size:0.88rem;">{t('about.values.card4.desc')}</p>
+          <h3 style="color:var(--clr-light-text);font-size:var(--fs-card-title);font-weight:var(--fw-card-title);margin-bottom:8px;">{t('about.values.card4.title')}</h3>
+           <p style="color:var(--clr-light-muted);font-size:var(--fs-card-body);">{t('about.values.card4.desc')}</p>
         </div>
       </div>
     </div>
@@ -207,7 +207,7 @@ const aboutSchema = {
     </div>
     <div class="container container--wide">
       <div class="text-center anim-fade-up">
-        <div class="section-label" style="margin-inline:auto; color: #00f0ff; border-color: rgba(0,240,255,0.3);">{t('about.history.label')}</div>
+        <div class="section-label" style="margin-inline:auto;">{t('about.history.label')}</div>
         <h2 class="section-title">{t('about.history.title')}<span class="grad-text">{t('about.history.titleHighlight')}</span></h2>
         <p class="section-sub" style="color: rgba(255,255,255,0.6);">{t('about.history.sub')}</p>
       </div>
@@ -624,9 +624,9 @@ const aboutSchema = {
 .node-year {
   font-size: 1.4rem;
   font-weight: 800;
-  color: #00f0ff;
+  color: var(--clr-primary);
   margin-bottom: 20px;
-  text-shadow: 0 0 10px rgba(0,240,255,0.3);
+  text-shadow: 0 0 10px rgba(0, 200, 150, 0.3);
 }
 
 .node-dot {

--- a/src/page-templates/AcademyPage.astro
+++ b/src/page-templates/AcademyPage.astro
@@ -299,12 +299,12 @@ const faqSchema = {
 .luxury-card:hover { transform: translateY(-8px); border-color: var(--clr-primary); }
 .curriculum-card { display: flex; flex-direction: column; height: 100%; }
 .curriculum-list { list-style: none; padding: 0; margin: 0; }
-.curriculum-list li { position: relative; padding-left: 24px; margin-bottom: 12px; font-size: 0.95rem; color: #475569; }
+.curriculum-list li { position: relative; padding-left: 24px; margin-bottom: 12px; font-size: 0.95rem; color: var(--clr-light-muted); }
 .curriculum-list li::before { content: "\2192"; position: absolute; left: 0; color: var(--clr-primary); font-weight: 700; }
 .highlight-box { margin-top: auto; padding-top: 24px; }
 .divider { height: 1px; background: #E2E8F0; margin-bottom: 20px; }
 .highlight-box ul { list-style: none; padding: 0; }
-.highlight-box li { font-size: 0.85rem; font-weight: 600; color: #1E293B; margin-bottom: 8px; }
+.highlight-box li { font-size: 0.85rem; font-weight: 600; color: var(--clr-light-text); margin-bottom: 8px; }
 .uni-grid { display: grid; grid-template-columns: repeat(5, 1fr); gap: 16px; margin-top: 48px; }
 .uni-tile { background: #FFF; border: 1px solid #E2E8F0; border-radius: 12px; padding: 16px; text-align: center; display: flex; align-items: center; justify-content: center; min-height: 120px; transition: transform 0.3s ease, box-shadow 0.3s ease; }
 .uni-tile:hover { transform: translateY(-4px); box-shadow: 0 12px 30px rgba(0,0,0,0.06); border-color: var(--clr-primary); }
@@ -314,11 +314,11 @@ const faqSchema = {
 @media (max-width: 600px) { .uni-grid { grid-template-columns: repeat(2, 1fr); } }
 .testimonial-card { display: flex; flex-direction: column; background: #FFF; border: 1px solid #E2E8F0; }
 .quote-icon { font-size: 4rem; color: var(--clr-primary); line-height: 1; height: 3rem; margin-top: -10px; opacity: 0.2; }
-.quote-text { font-size: 1rem; color: #475569; font-style: italic; line-height: 1.6; margin-bottom: 32px; flex: 1; }
+.quote-text { font-size: 1rem; color: var(--clr-light-muted); font-style: italic; line-height: 1.6; margin-bottom: 32px; flex: 1; }
 .author-info { display: flex; align-items: center; gap: 16px; border-top: 1px solid #F1F5F9; padding-top: 20px; }
 .author-avatar { width: 44px; height: 44px; background: var(--grad-brand); border-radius: 50%; display: flex; align-items: center; justify-content: center; color: #FFF; font-weight: 800; }
-.author-name { font-weight: 750; color: #1E293B; font-size: 0.95rem; }
-.author-role { font-size: 0.8rem; color: #64748B; }
-.faq-item h4 { font-size: 1.1rem; font-weight: 800; color: #1E293B; margin-bottom: 12px; }
-.faq-item p { font-size: 0.95rem; color: #64748B; }
+.author-name { font-weight: 700; color: var(--clr-light-text); font-size: 0.95rem; }
+.author-role { font-size: 0.8rem; color: var(--clr-light-muted); }
+.faq-item h4 { font-size: var(--fs-card-title); font-weight: var(--fw-card-title); color: var(--clr-light-text); margin-bottom: 12px; }
+.faq-item p { font-size: var(--fs-card-body); color: var(--clr-light-muted); }
 </style>

--- a/src/page-templates/CareersPage.astro
+++ b/src/page-templates/CareersPage.astro
@@ -278,12 +278,12 @@ const whyStats = [
   margin-bottom: 24px;
 }
 .role-icon svg { width: 28px; height: 28px; }
-.role-card h3 { font-size: 1.3rem; font-weight: 800; color: var(--clr-light-text); margin-bottom: 16px; }
-.role-card p { font-size: 1rem; color: var(--clr-light-muted); line-height: 1.6; }
+.role-card h3 { font-size: var(--fs-card-title); font-weight: var(--fw-card-title); color: var(--clr-light-text); margin-bottom: 16px; }
+.role-card p { font-size: var(--fs-card-body); color: var(--clr-light-muted); line-height: 1.6; }
 
 /* Value Cards */
-.value-card h3 { font-size: 1.4rem; color: var(--clr-light-text); margin-bottom: 16px; }
-.value-card p { font-size: 1.05rem; color: var(--clr-light-muted); line-height: 1.6; }
+.value-card h3 { font-size: var(--fs-card-title); font-weight: var(--fw-card-title); color: var(--clr-light-text); margin-bottom: 16px; }
+.value-card p { font-size: var(--fs-card-body); color: var(--clr-light-muted); line-height: 1.6; }
 
 /* Application Box */
 .apply-box {
@@ -301,8 +301,8 @@ const whyStats = [
   flex-direction: column;
   gap: 32px;
 }
-.info-item strong { display: block; color: #111827; font-size: 1.1rem; margin-bottom: 8px; }
-.info-item p { color: #475569; font-size: 0.95rem; line-height: 1.6; }
+.info-item strong { display: block; color: var(--clr-light-text); font-size: 1.1rem; margin-bottom: 8px; }
+.info-item p { color: var(--clr-light-muted); font-size: 0.95rem; line-height: 1.6; }
 .apply-cta { display: flex; flex-direction: column; align-items: center; gap: 12px; }
 .sub-email { color: var(--clr-light-muted); font-size: 0.9rem; font-weight: 500; opacity: 0.7; }
 

--- a/src/page-templates/ClientsPage.astro
+++ b/src/page-templates/ClientsPage.astro
@@ -328,18 +328,18 @@ const sortedSectors = sectors.map(sector => ({
 .success-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 20px; }
 .success-card { padding: 32px 28px; border-radius: 24px; background: #FFFFFF; border: 1px solid #E2E8F0; transition: all 0.3s ease; display: flex; flex-direction: column; gap: 12px; box-shadow: 0 4px 16px rgba(15,23,42,0.03); }
 .success-card:hover { transform: translateY(-6px); box-shadow: 0 20px 40px rgba(0,200,150,0.08); border-color: rgba(0,200,150,0.25); }
-.success-icon { width: 56px; height: 56px; display: flex; align-items: center; justify-content: center; background: linear-gradient(135deg, rgba(0,200,150,0.08), rgba(0,159,227,0.06)); border: 1px solid rgba(0,200,150,0.18); border-radius: 16px; color: #00C896; margin-bottom: 4px; }
-.success-card h3 { font-size: 1.1rem; font-weight: 800; color: #0F172A; margin: 0; letter-spacing: -0.01em; }
-.success-short { font-size: 0.95rem; color: #64748B; line-height: 1.55; margin: 0; }
+.success-icon { width: 56px; height: 56px; display: flex; align-items: center; justify-content: center; background: linear-gradient(135deg, rgba(0,200,150,0.08), rgba(0,159,227,0.06)); border: 1px solid rgba(0,200,150,0.18); border-radius: 16px; color: var(--clr-primary); margin-bottom: 4px; }
+.success-card h3 { font-size: var(--fs-card-title); font-weight: var(--fw-card-title); color: var(--clr-light-text); margin: 0; letter-spacing: -0.01em; }
+.success-short { font-size: var(--fs-card-body); color: var(--clr-light-muted); line-height: 1.55; margin: 0; }
 .success-detail { margin-top: 8px; padding-top: 16px; border-top: 1px solid #F1F5F9; }
-.success-detail p { font-size: 0.88rem; color: #64748B; line-height: 1.6; margin-bottom: 12px; }
+.success-detail p { font-size: var(--fs-card-body); color: var(--clr-light-muted); line-height: 1.6; margin-bottom: 12px; }
 .success-metrics { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 6px; }
-.success-metrics li { font-size: 0.85rem; font-weight: 700; color: #00C896; padding-left: 4px; }
+.success-metrics li { font-size: 0.85rem; font-weight: 700; color: var(--clr-primary); padding-left: 4px; }
 @media (max-width: 1100px) { .success-grid { grid-template-columns: repeat(2, 1fr); } }
 @media (max-width: 640px) { .success-grid { grid-template-columns: 1fr; } }
 
 .tabs-nav { display: flex; justify-content: center; gap: 12px; margin-bottom: 40px; flex-wrap: wrap; }
-.tab-btn { padding: 12px 24px; border-radius: 99px; background: #fff; border: 1px solid #e2e8f0; color: #64748b; font-weight: 600; cursor: pointer; transition: all 0.2s ease; }
+.tab-btn { padding: 12px 24px; border-radius: 99px; background: #fff; border: 1px solid #e2e8f0; color: var(--clr-light-muted); font-weight: 600; cursor: pointer; transition: all 0.2s ease; }
 .tab-btn.active { background: var(--clr-primary); border-color: var(--clr-primary); color: #fff; box-shadow: 0 10px 20px rgba(0, 200, 150, 0.2); }
 
 .tabs-content { position: relative; min-height: 400px; }
@@ -348,7 +348,7 @@ const sortedSectors = sectors.map(sector => ({
 
 .sector-header { background: #fff; padding: 30px; border-radius: 24px; margin-bottom: 40px; border-left: 6px solid var(--clr-primary); box-shadow: 0 10px 30px rgba(0,0,0,0.03); }
 .outcomes-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 32px; }
-.outcome-item { display: flex; align-items: center; gap: 12px; font-size: 0.95rem; font-weight: 600; color: #1e293b; }
+.outcome-item { display: flex; align-items: center; gap: 12px; font-size: 0.95rem; font-weight: 600; color: var(--clr-light-text); }
 .check-icon { color: var(--clr-primary); flex-shrink: 0; }
 
 .sector-logos { display: grid; grid-template-columns: repeat(6, 1fr); gap: 16px; margin-bottom: 40px; }
@@ -370,8 +370,8 @@ const sortedSectors = sectors.map(sector => ({
 .impact-list { display: grid; gap: 32px; margin-top: 40px; }
 .impact-item { display: flex; gap: 24px; }
 .impact-icon { width: 48px; height: 48px; border-radius: 12px; background: rgba(0, 200, 150, 0.1); color: var(--clr-primary); display: flex; align-items: center; justify-content: center; font-weight: 800; font-size: 1.1rem; flex-shrink: 0; }
-.impact-content h3 { font-size: 1.25rem; color: #1e293b; margin-bottom: 4px; }
-.impact-content p { font-size: 0.95rem; color: #64748b; line-height: 1.5; }
+.impact-content h3 { font-size: var(--fs-card-title); font-weight: var(--fw-card-title); color: var(--clr-light-text); margin-bottom: 4px; }
+.impact-content p { font-size: var(--fs-card-body); color: var(--clr-light-muted); line-height: 1.5; }
 
 @keyframes fadeIn { from { opacity: 0; transform: translateY(10px); } to { opacity: 1; transform: translateY(0); } }
 

--- a/src/page-templates/ContactPage.astro
+++ b/src/page-templates/ContactPage.astro
@@ -186,7 +186,7 @@ const contactSchema = {
           </div>
 
           <div class="contact-why anim-fade-up">
-            <h3 style="color:var(--clr-light-text);font-size:1.1rem;margin-bottom:16px;">{t('contact.why.title')}</h3>
+            <h3 style="color:var(--clr-light-text);font-size:var(--fs-card-title);font-weight:var(--fw-card-title);margin-bottom:16px;">{t('contact.why.title')}</h3>
             <ul class="contact-why__list">
               <li>{t('contact.why.stat1')}</li>
               <li>{t('contact.why.stat2')}</li>

--- a/src/page-templates/DataPlatformsPage.astro
+++ b/src/page-templates/DataPlatformsPage.astro
@@ -360,8 +360,8 @@ const breadcrumbs = [
   .metric-dot.teal { background: #00c896 !important; box-shadow: 0 0 10px rgba(0, 200, 150, 0.5) !important; }
   .metric-dot.amber { background: #ff9800 !important; box-shadow: 0 0 10px rgba(255, 152, 0, 0.5) !important; }
   .metric-header span { font-size: 0.7rem; font-weight: 800; text-transform: uppercase; letter-spacing: 0.1em; color: var(--clr-light-muted); }
-  .metric-body h3 { font-size: 1.1rem; color: var(--clr-light-text); margin-bottom: 8px; font-weight: 800; }
-  .metric-body p { font-size: 0.9rem; color: var(--clr-light-muted); line-height: 1.5; margin: 0; }
+  .metric-body h3 { font-size: var(--fs-card-title); color: var(--clr-light-text); margin-bottom: 8px; font-weight: var(--fw-card-title); }
+  .metric-body p { font-size: var(--fs-card-body); color: var(--clr-light-muted); line-height: 1.5; margin: 0; }
   .cap-icon-box { width: 48px; height: 48px; background: rgba(0, 200, 150, 0.1); color: var(--clr-primary); border-radius: 12px; display: flex; align-items: center; justify-content: center; margin-bottom: 24px; }
   .cap-icon-box svg { width: 26px; height: 26px; }
   .kpi-banner { display: grid; grid-template-columns: repeat(3, 1fr); gap: 32px; background: #f8fafc; border: 1px solid #e2e8f0; border-radius: 20px; padding: 32px; margin-top: 64px; width: 100%; box-sizing: border-box; }
@@ -399,8 +399,8 @@ const breadcrumbs = [
   .serv-list li { margin-bottom: 10px; font-size: 0.95rem; color: var(--clr-light-muted); }
   .d-step { display: flex; gap: 16px; align-items: flex-start; }
   .d-num { width: 44px; height: 44px; background: var(--clr-primary); color: #fff; border-radius: 12px; display: flex; align-items: center; justify-content: center; font-weight: 900; font-size: 1.1rem; flex-shrink: 0; }
-  .d-info h4 { font-size: 1.1rem; color: var(--clr-light-text); margin-bottom: 4px; }
-  .d-info p { font-size: 0.9rem; color: var(--clr-light-muted); }
+  .d-info h4 { font-size: var(--fs-card-title); font-weight: var(--fw-card-title); color: var(--clr-light-text); margin-bottom: 4px; }
+  .d-info p { font-size: var(--fs-card-body); color: var(--clr-light-muted); }
   @media (max-width: 1100px) {
     .architecture-main { overflow-x: auto; -webkit-overflow-scrolling: touch; margin-inline: -10px; padding-inline: 10px; }
     .archi-card-modern { padding: 32px 16px; border-radius: 24px; width: 100%; }

--- a/src/page-templates/HomePage.astro
+++ b/src/page-templates/HomePage.astro
@@ -143,22 +143,22 @@ const websiteSchema = {
         <div class="metric-item">
           <span class="metric-label" style="font-weight: 800; color: #111; text-transform: uppercase; font-size: 0.85rem; letter-spacing: 0.05em; margin-bottom: 8px; display: block;">{t('home.globalImpact.metric1.label')}</span>
           <span class="metric-number"><span class="counter" data-target="20">0</span>{t('home.globalImpact.metric1.number')}</span>
-          <p style="font-size: 0.9rem; color: #64748b; margin-top: 8px;">{t('home.globalImpact.metric1.desc')}</p>
+          <p style="font-size: 0.9rem; color: var(--clr-light-muted); margin-top: 8px;">{t('home.globalImpact.metric1.desc')}</p>
         </div>
         <div class="metric-item">
           <span class="metric-label" style="font-weight: 800; color: #111; text-transform: uppercase; font-size: 0.85rem; letter-spacing: 0.05em; margin-bottom: 8px; display: block;">{t('home.globalImpact.metric2.label')}</span>
           <span class="metric-number"><span class="counter" data-target="80">0</span>{t('home.globalImpact.metric2.number')}</span>
-          <p style="font-size: 0.9rem; color: #64748b; margin-top: 8px;">{t('home.globalImpact.metric2.desc')}</p>
+          <p style="font-size: 0.9rem; color: var(--clr-light-muted); margin-top: 8px;">{t('home.globalImpact.metric2.desc')}</p>
         </div>
         <div class="metric-item">
           <span class="metric-label" style="font-weight: 800; color: #111; text-transform: uppercase; font-size: 0.85rem; letter-spacing: 0.05em; margin-bottom: 8px; display: block;">{t('home.globalImpact.metric3.label')}</span>
           <span class="metric-number"><span class="counter" data-target="100">0</span>{t('home.globalImpact.metric3.number')}</span>
-          <p style="font-size: 0.9rem; color: #64748b; margin-top: 8px;">{t('home.globalImpact.metric3.desc')}</p>
+          <p style="font-size: 0.9rem; color: var(--clr-light-muted); margin-top: 8px;">{t('home.globalImpact.metric3.desc')}</p>
         </div>
         <div class="metric-item">
           <span class="metric-label" style="font-weight: 800; color: #111; text-transform: uppercase; font-size: 0.85rem; letter-spacing: 0.05em; margin-bottom: 8px; display: block;">{t('home.globalImpact.metric4.label')}</span>
           <span class="metric-number"><span class="counter" data-target="30">0</span>{t('home.globalImpact.metric4.number')}</span>
-          <p style="font-size: 0.9rem; color: #64748b; margin-top: 8px;">{t('home.globalImpact.metric4.desc')}</p>
+          <p style="font-size: 0.9rem; color: var(--clr-light-muted); margin-top: 8px;">{t('home.globalImpact.metric4.desc')}</p>
         </div>
       </div>
     </div>
@@ -1120,8 +1120,8 @@ img[alt="Hopi"] {
   margin-bottom: 24px;
 }
 .cap-icon-box svg { width: 26px; height: 26px; }
-.cap-card-v2 h3 { font-size: 1.25rem; font-weight: 850; color: var(--clr-light-text); margin-bottom: 14px; letter-spacing: -0.01em; line-height: 1.3; }
-.cap-card-v2 p { font-size: 0.95rem; color: var(--clr-light-muted); line-height: 1.6; margin: 0; }
+.cap-card-v2 h3 { font-size: var(--fs-card-title); font-weight: var(--fw-card-title); color: var(--clr-light-text); margin-bottom: 14px; letter-spacing: -0.01em; line-height: 1.3; }
+.cap-card-v2 p { font-size: var(--fs-card-body); color: var(--clr-light-muted); line-height: 1.6; margin: 0; }
 
 @media (max-width: 1200px) {
   .cap-grid-row-2 { grid-template-columns: repeat(2, 1fr); }
@@ -1150,8 +1150,7 @@ img[alt="Hopi"] {
   border-color: var(--clr-primary);
   box-shadow: 0 20px 40px rgba(0,0,0,0.06);
 }
-.dwh-card h3 { font-size: 1.4rem; font-weight: 800; color: var(--clr-light-text); margin-bottom: 16px; }
-.dwh-card p { font-size: 1rem; color: var(--clr-light-muted); line-height: 1.6; margin-bottom: 24px; }
+/* .dwh-card h3 / p — using global.css definitions (1.15rem / 0.88rem) */
 .dwh-card__list {
   list-style: none;
   padding: 0;

--- a/src/page-templates/InsightsPage.astro
+++ b/src/page-templates/InsightsPage.astro
@@ -158,7 +158,7 @@ const allTopics = Array.from(new Set(insights.flatMap(i => i.topics))).sort();
         <div>
           <div class="div-badge">{t('insights.featured.badge')}</div>
           <h2 style="color:var(--clr-light-text); font-size: 2.5rem; line-height: 1.1; margin-bottom: 24px;">{t('insights.featured.title')}<span class="grad-text">{t('insights.featured.titleHighlight')}</span></h2>
-          <p style="color:var(--clr-light-muted); font-size: 1.1rem; line-height: 1.6; margin-bottom: 32px;">
+          <p style="color:var(--clr-light-muted); font-size: var(--fs-section-sub); line-height: 1.6; margin-bottom: 32px;">
             {t('insights.featured.desc')}
           </p>
           <a href={tp('/insights/genai-guven-standardi')} class="btn btn-primary btn-pill btn-lg">{t('insights.featured.cta')}</a>
@@ -229,16 +229,16 @@ const allTopics = Array.from(new Set(insights.flatMap(i => i.topics))).sort();
 .insights-toolbar { display: flex; gap: 20px; margin-bottom: 48px; margin-top: 32px; }
 .search-box { flex: 2; }
 .filter-box { flex: 1; }
-.insights-toolbar input, .insights-toolbar select { width: 100%; padding: 14px 20px; border-radius: 12px; border: 1px solid #e2e8f0; background: #fff; font-size: 0.95rem; color: #1e293b; outline: none; transition: border-color 0.2s ease; }
+.insights-toolbar input, .insights-toolbar select { width: 100%; padding: 14px 20px; border-radius: 12px; border: 1px solid #e2e8f0; background: #fff; font-size: 0.95rem; color: var(--clr-light-text); outline: none; transition: border-color 0.2s ease; }
 .insights-toolbar input:focus, .insights-toolbar select:focus { border-color: var(--clr-primary); }
 .insight-card { display: flex; flex-direction: column; padding: 32px; text-decoration: none; transition: all 0.3s ease; }
 .insight-card:hover { transform: translateY(-8px); border-color: var(--clr-primary); box-shadow: 0 20px 40px rgba(0,200,150,0.08); }
 .insight-meta { display: flex; align-items: center; gap: 10px; font-size: 0.75rem; font-weight: 600; color: var(--clr-light-muted); text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: 16px; }
 .insight-meta .dot { width: 4px; height: 4px; border-radius: 50%; background: #cbd5e1; }
-.insight-card h3 { font-size: 1.25rem; color: var(--clr-light-text); margin-bottom: 12px; line-height: 1.4; }
-.insight-card p { font-size: 0.95rem; color: var(--clr-light-muted); line-height: 1.6; margin-bottom: 24px; flex-grow: 1; }
+.insight-card h3 { font-size: var(--fs-card-title); font-weight: var(--fw-card-title); color: var(--clr-light-text); margin-bottom: 12px; line-height: 1.4; }
+.insight-card p { font-size: var(--fs-card-body); color: var(--clr-light-muted); line-height: 1.6; margin-bottom: 24px; flex-grow: 1; }
 .insight-tags { display: flex; flex-wrap: wrap; gap: 8px; }
-.topic-pill { font-size: 0.7rem; font-weight: 700; padding: 4px 10px; border-radius: 999px; background: #f1f5f9; color: #475569; }
+.topic-pill { font-size: 0.7rem; font-weight: 700; padding: 4px 10px; border-radius: 999px; background: #f1f5f9; color: var(--clr-light-muted); }
 .div-badge { display: inline-block; padding: 6px 16px; background: rgba(16,185,129,0.1); color: var(--clr-primary); border-radius: 100px; font-size: 0.75rem; font-weight: 700; text-transform: uppercase; margin-bottom: 24px; }
 
 @media (max-width: 768px) {

--- a/src/page-templates/PartnersPage.astro
+++ b/src/page-templates/PartnersPage.astro
@@ -149,7 +149,7 @@ const partners = [
   background: linear-gradient(135deg, rgba(0,200,150,0.09), rgba(0,159,227,0.06));
   border: 1px solid rgba(0,200,150,0.2);
   border-radius: 14px;
-  color: #00C896;
+  color: var(--clr-primary);
   margin-bottom: 6px;
   transition: all 0.3s ease;
 }
@@ -160,7 +160,7 @@ const partners = [
 .pcard__name {
   font-size: 1rem;
   font-weight: 800;
-  color: #0F172A;
+  color: var(--clr-light-text);
   letter-spacing: -0.01em;
   line-height: 1.2;
 }
@@ -169,7 +169,7 @@ const partners = [
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.07em;
-  color: #94A3B8;
+  color: var(--clr-light-muted);
 }
 @media (max-width: 1100px) {
   .pcard-grid { grid-template-columns: repeat(3, 1fr) !important; }
@@ -191,8 +191,8 @@ const partners = [
 }
 
 .cta-banner { background: #FFF; border: 1px solid #E2E8F0; border-radius: 24px; padding: 40px; display: flex; align-items: center; justify-content: space-between; box-shadow: 0 20px 50px rgba(0,0,0,0.03); }
-.cta-banner-content h3 { font-size: 1.5rem; font-weight: 900; color: #1E293B; margin-bottom: 8px; }
-.cta-banner-content p { color: #64748B; }
+.cta-banner-content h3 { font-size: 1.5rem; font-weight: 900; color: var(--clr-light-text); margin-bottom: 8px; }
+.cta-banner-content p { color: var(--clr-light-muted); }
 .cta-banner-actions { display: flex; gap: 16px; }
 
 @media (max-width: 768px) {

--- a/src/page-templates/SolutionsPage.astro
+++ b/src/page-templates/SolutionsPage.astro
@@ -176,7 +176,7 @@ const detailLabelsJson = JSON.stringify({
         line-height:1.08;
         letter-spacing:-.02em;
         font-weight:750;
-        color: #0F172A;
+        color: var(--clr-light-text);
       }
       @media(max-width:560px){ .ai-title{font-size:32px;} }
       .ai-lead{
@@ -202,7 +202,7 @@ const detailLabelsJson = JSON.stringify({
         font-weight:650;
         letter-spacing:-.01em;
         margin-bottom:4px;
-        color: #0F172A;
+        color: var(--clr-light-text);
       }
       .ai-bullets li{
         list-style:none;
@@ -279,7 +279,7 @@ const detailLabelsJson = JSON.stringify({
         font-size:15px;
         letter-spacing:-.01em;
         font-weight:700;
-        color: #0F172A;
+        color: var(--clr-light-text);
       }
       .ai-card p{
         margin:0;
@@ -321,7 +321,7 @@ const detailLabelsJson = JSON.stringify({
         font-size:20px;
         letter-spacing:-.01em;
         font-weight:750;
-        color: #0F172A;
+        color: var(--clr-light-text);
       }
       .ai-subhead p{
         margin:0;
@@ -354,7 +354,7 @@ const detailLabelsJson = JSON.stringify({
         font-size:14px;
         font-weight:750;
         letter-spacing:-.01em;
-        color: #0F172A;
+        color: var(--clr-light-text);
       }
       .ai-mini p{
         margin:0;
@@ -556,7 +556,7 @@ const detailLabelsJson = JSON.stringify({
         margin:0 0 12px 0;
         font-size:20px;
         font-weight:750;
-        color: #0F172A;
+        color: var(--clr-light-text);
         letter-spacing: -0.01em;
       }
       .ai-sol-card p {
@@ -651,8 +651,8 @@ const detailLabelsJson = JSON.stringify({
     <div class="container">
       <div class="text-center anim-fade-up" style="margin-bottom:60px;">
         <div class="section-label" style="margin-inline:auto;">{t('solutions.howItWorks.label')}</div>
-        <h2 class="section-title" style="color:#0F172A;">{t('solutions.howItWorks.title')}<span class="grad-text">{t('solutions.howItWorks.titleHighlight')}</span></h2>
-        <p class="section-sub" style="max-width:680px; margin-inline:auto; color:#64748B;">
+        <h2 class="section-title" style="color:var(--clr-light-text);">{t('solutions.howItWorks.title')}<span class="grad-text">{t('solutions.howItWorks.titleHighlight')}</span></h2>
+        <p class="section-sub" style="max-width:680px; margin-inline:auto; color:var(--clr-light-muted);">
           {t('solutions.howItWorks.sub')}
         </p>
       </div>
@@ -763,7 +763,7 @@ const detailLabelsJson = JSON.stringify({
           </div>
         </div>
         <div class="archi-note" style="background: rgba(15,23,42,0.02); border-top: 1px solid rgba(15,23,42,0.08); text-align: center;">
-          <p style="color: #0F172A; font-weight: 600; font-size: 1.05rem;">{t('solutions.architecture.note')}</p>
+          <p style="color: var(--clr-light-text); font-weight: 600; font-size: 1.05rem;">{t('solutions.architecture.note')}</p>
         </div>
       </div>
 
@@ -1040,18 +1040,18 @@ const detailLabelsJson = JSON.stringify({
   background: linear-gradient(135deg, rgba(0,200,150,0.08), rgba(0,159,227,0.06));
   border: 1px solid rgba(0,200,150,0.2);
   border-radius: 18px;
-  color: #00C896;
+  color: var(--clr-primary);
 }
 .hiw-title {
   font-size: 1.1rem;
   font-weight: 800;
-  color: #0F172A;
+  color: var(--clr-light-text);
   margin: 0 0 10px 0;
   letter-spacing: -0.01em;
 }
 .hiw-desc {
   font-size: 0.95rem;
-  color: #64748B;
+  color: var(--clr-light-muted);
   line-height: 1.6;
   margin: 0;
 }
@@ -1068,7 +1068,7 @@ const detailLabelsJson = JSON.stringify({
   right: -10px;
   top: 50%;
   transform: translateY(-50%);
-  color: #00C896;
+  color: var(--clr-primary);
   font-size: 1rem;
   line-height: 1;
 }
@@ -1082,24 +1082,24 @@ const detailLabelsJson = JSON.stringify({
 
 .capabilities-grid { display: grid; grid-template-columns: 1fr 1.5fr; gap: 32px; align-items: stretch; margin-top: 48px; }
 .cap-card { background: #FFF; border: 1px solid #E2E8F0; border-radius: 32px; padding: 48px; box-shadow: 0 10px 30px rgba(0,0,0,0.02); display: flex; flex-direction: column; }
-.cap-card__title { font-size: 2rem; font-weight: 950; color: #0F172A; margin-bottom: 32px; letter-spacing: -0.02em; line-height: 1.1; min-height: 4.4rem; display: flex; align-items: flex-start; }
-.cap-card__desc { font-size: 1.1rem; color: #64748B; line-height: 1.6; margin-bottom: 40px; min-height: 4.8rem; }
+.cap-card__title { font-size: 2rem; font-weight: 950; color: var(--clr-light-text); margin-bottom: 32px; letter-spacing: -0.02em; line-height: 1.1; min-height: 4.4rem; display: flex; align-items: flex-start; }
+.cap-card__desc { font-size: 1.1rem; color: var(--clr-light-muted); line-height: 1.6; margin-bottom: 40px; min-height: 4.8rem; }
 
 /* Analytics Card Layout */
 .cap-card__row { display: grid; grid-template-columns: 1fr 1fr; gap: 40px; }
 .cap-block__title { color: var(--clr-primary); font-size: 1.1rem; font-weight: 950; margin-bottom: 12px; }
-.cap-block__text { font-size: 1rem; color: #475569; line-height: 1.6; }
+.cap-block__text { font-size: 1rem; color: var(--clr-light-muted); line-height: 1.6; }
 
 /* AI Card Layout */
 .cap-ai-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; margin-bottom: 32px; }
 .cap-ai-item { background: #F8FAFC; border: 1px solid #E2E8F0; padding: 24px; border-radius: 20px; }
-.cap-ai-item h5 { font-size: 1rem; font-weight: 950; color: #0F172A; margin-bottom: 8px; }
-.cap-ai-item p { font-size: 0.85rem; color: #64748B; margin: 0; line-height: 1.5; }
+.cap-ai-item h5 { font-size: 1rem; font-weight: 950; color: var(--clr-light-text); margin-bottom: 8px; }
+.cap-ai-item p { font-size: 0.85rem; color: var(--clr-light-muted); margin: 0; line-height: 1.5; }
 
 .cap-expertise-row { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; margin-top: auto; border-top: 1px solid #F1F5F9; padding-top: 32px; }
-.cap-expertise h6 { font-size: 1rem; font-weight: 950; color: #0F172A; margin-bottom: 16px; }
+.cap-expertise h6 { font-size: 1rem; font-weight: 950; color: var(--clr-light-text); margin-bottom: 16px; }
 .cap-list { list-style: none; padding: 0; margin: 0; }
-.cap-list li { font-size: 0.9rem; color: #475569; margin-bottom: 10px; padding-left: 20px; position: relative; line-height: 1.4; }
+.cap-list li { font-size: 0.9rem; color: var(--clr-light-muted); margin-bottom: 10px; padding-left: 20px; position: relative; line-height: 1.4; }
 .cap-list li::before { content: ""; position: absolute; left: 0; top: 10px; width: 6px; height: 6px; background: var(--clr-primary); border-radius: 50%; }
 
 @media (max-width: 1200px) {
@@ -1218,13 +1218,13 @@ const detailLabelsJson = JSON.stringify({
 .bp-strip.active { background: #FFF; border-color: var(--clr-primary); box-shadow: 0 20px 40px rgba(0,200,150,0.1); }
 
 .bp-strip__data { flex: 1; }
-.bp-strip__data h3 { font-size: 1.8rem; font-weight: 950; color: #1E293B; margin-bottom: 12px; letter-spacing: -0.02em; }
+.bp-strip__data h3 { font-size: 1.8rem; font-weight: 950; color: var(--clr-light-text); margin-bottom: 12px; letter-spacing: -0.02em; }
 
 @media (max-width: 768px) {
   .bp-strip__data h3 { font-size: 1.4rem; }
 }
 
-.bp-strip__data p { font-size: 1.15rem; color: #64748B; margin: 0; line-height: 1.6; width: 100%; }
+.bp-strip__data p { font-size: 1.15rem; color: var(--clr-light-muted); margin: 0; line-height: 1.6; width: 100%; }
 
 @media (max-width: 768px) {
   .bp-strip__data p { font-size: 1rem; }
@@ -1267,29 +1267,29 @@ const detailLabelsJson = JSON.stringify({
 .bp-detail-widget.active { opacity: 1; pointer-events: auto; transform: translateY(0) scale(1); }
 
 /* Detail Content Styles */
-.dt-label { font-size: 0.75rem; font-weight: 950; color: #00C896; text-transform: uppercase; letter-spacing: 0.25em; border-bottom: 2px solid #F1F5F9; padding-bottom: 12px; margin-bottom: 24px; display: block; }
-.dt-title { font-size: 2.2rem; font-weight: 950; color: #111827; margin-bottom: 20px; letter-spacing: -0.05em; line-height: 1.1; }
-.dt-desc { font-size: 1.05rem; color: #475569; line-height: 1.6; margin-bottom: 32px; }
+.dt-label { font-size: 0.75rem; font-weight: 950; color: var(--clr-primary); text-transform: uppercase; letter-spacing: 0.25em; border-bottom: 2px solid #F1F5F9; padding-bottom: 12px; margin-bottom: 24px; display: block; }
+.dt-title { font-size: 2.2rem; font-weight: 950; color: var(--clr-light-text); margin-bottom: 20px; letter-spacing: -0.05em; line-height: 1.1; }
+.dt-desc { font-size: 1.05rem; color: var(--clr-light-muted); line-height: 1.6; margin-bottom: 32px; }
 .dt-sec { margin-bottom: 32px; }
-.dt-h { font-size: 0.8rem; font-weight: 950; color: #111827; text-transform: uppercase; letter-spacing: 0.15em; margin-bottom: 16px; padding-left: 12px; border-left: 3px solid #00C896; }
+.dt-h { font-size: 0.8rem; font-weight: 950; color: var(--clr-light-text); text-transform: uppercase; letter-spacing: 0.15em; margin-bottom: 16px; padding-left: 12px; border-left: 3px solid #00C896; }
 .dt-list { list-style: none; padding: 0; margin: 0; }
-.dt-list li { font-size: 1.05rem; color: #1E293B; margin-bottom: 12px; display: flex !important; align-items: flex-start !important; gap: 12px !important; line-height: 1.5; }
-.dt-list li::before { content: "\2714" !important; color: #00C896 !important; font-weight: 950 !important; flex-shrink: 0; display: inline-block !important; }
+.dt-list li { font-size: 1.05rem; color: var(--clr-light-text); margin-bottom: 12px; display: flex !important; align-items: flex-start !important; gap: 12px !important; line-height: 1.5; }
+.dt-list li::before { content: "\2714" !important; color: var(--clr-primary) !important; font-weight: 950 !important; flex-shrink: 0; display: inline-block !important; }
 .dt-meta { display: grid; gap: 20px; border-top: 2px solid #F1F5F9; padding-top: 24px; margin-top: 10px; }
-.dt-meta-i b { display: block; font-size: 0.8rem; font-weight: 950; color: #111827; margin-bottom: 6px; text-transform: uppercase; }
-.dt-meta-i p { font-size: 1rem; color: #64748B; margin: 0; line-height: 1.5; }
+.dt-meta-i b { display: block; font-size: 0.8rem; font-weight: 950; color: var(--clr-light-text); margin-bottom: 6px; text-transform: uppercase; }
+.dt-meta-i p { font-size: 1rem; color: var(--clr-light-muted); margin: 0; line-height: 1.5; }
 
 /* Mobile detail close button */
 .bp-detail-close {
   position: absolute; top: 16px; right: 16px;
   width: 44px; height: 44px; border-radius: 50%;
-  background: #F1F5F9; color: #1E293B;
+  background: #F1F5F9; color: var(--clr-light-text);
   display: none; align-items: center; justify-content: center;
   transition: 0.3s; z-index: 100; border: 1px solid #E2E8F0;
   cursor: pointer;
 }
 .bp-detail-close svg { width: 22px; height: 22px; pointer-events: none; stroke-width: 3; }
-.bp-detail-close:hover { background: #00C896; color: #FFF; border-color: #00C896; }
+.bp-detail-close:hover { background: #00C896; color: #FFF; border-color: var(--clr-primary); }
 
 @media (max-width: 1400px) {
   .bp-browser-grid { grid-template-columns: 1fr; gap: 48px; }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -34,6 +34,13 @@
   --font: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
   --container: 1280px;
   --header-h: 72px;
+
+  /* Typography scale (added in typography pass) */
+  --fs-card-title: 1.15rem;
+  --fs-card-body: 0.88rem;
+  --fs-section-sub: 1.15rem;
+  --fs-meta: 0.85rem;
+  --fw-card-title: 700;
 }
 
 /* ── Reset ──────────────────────────────────────── */
@@ -819,14 +826,14 @@ p {
 }
 
 .cap-card h3 {
-  font-size: 1.15rem;
-  font-weight: 700;
+  font-size: var(--fs-card-title);
+  font-weight: var(--fw-card-title);
   color: var(--clr-light-text);
   margin-bottom: 10px;
 }
 
 .cap-card p {
-  font-size: 0.88rem;
+  font-size: var(--fs-card-body);
   line-height: 1.65;
   color: var(--clr-light-muted);
 }
@@ -852,14 +859,14 @@ p {
 
 
 .dwh-card h3 {
-  font-size: 1.15rem;
-  font-weight: 700;
+  font-size: var(--fs-card-title);
+  font-weight: var(--fw-card-title);
   color: var(--clr-light-text);
   margin-bottom: 14px;
 }
 
 .dwh-card p {
-  font-size: 0.88rem;
+  font-size: var(--fs-card-body);
   line-height: 1.65;
   color: var(--clr-light-muted);
   margin-bottom: 22px;
@@ -949,14 +956,14 @@ p {
 }
 
 .step-card h3 {
-  font-size: 1.15rem;
-  font-weight: 700;
+  font-size: var(--fs-card-title);
+  font-weight: var(--fw-card-title);
   color: var(--clr-light-text);
   margin-bottom: 12px;
 }
 
 .step-card p {
-  font-size: 0.88rem;
+  font-size: var(--fs-card-body);
   line-height: 1.6;
   color: var(--clr-light-muted);
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -852,7 +852,7 @@ p {
 
 
 .dwh-card h3 {
-  font-size: 1.18rem;
+  font-size: 1.15rem;
   font-weight: 700;
   color: var(--clr-light-text);
   margin-bottom: 14px;
@@ -949,14 +949,14 @@ p {
 }
 
 .step-card h3 {
-  font-size: 1.1rem;
+  font-size: 1.15rem;
   font-weight: 700;
   color: var(--clr-light-text);
   margin-bottom: 12px;
 }
 
 .step-card p {
-  font-size: 1rem;
+  font-size: 0.88rem;
   line-height: 1.6;
   color: var(--clr-light-muted);
 }


### PR DESCRIPTION
## Summary

Phase 2 of the typography consistency pass. Following the initial card h3/p alignment in `faa4131`, this PR resolves the remaining inconsistencies across page templates.

- **Typography tokens** added to `global.css` (`--fs-card-title`, `--fs-card-body`, `--fs-section-sub`, `--fs-meta`, `--fw-card-title`) and applied to all card variants (cap-card, dwh-card, step-card, cap-card-v2, role-card, value-card, success-card, impact-content, insight-card, metric-body, d-info, faq-item, contact why)
- **Color cleanup**: hardcoded slate/gray hex (`#0F172A`, `#1E293B`, `#111827`, `#475569`, `#64748B`) replaced with `--clr-light-text` / `--clr-light-muted` tokens across 9 page templates
- **Critical fix**: removed `HomePage.astro` `.dwh-card` override that was shadowing the global rule (h3 was rendering at 1.4rem instead of the intended 1.15rem)
- **Off-brand color removed**: AboutPage timeline cyan (`#00f0ff`) → brand teal (`var(--clr-primary)`)
- **TR copy**: ROI calculator CTA shortened from "Verinizin Değerini Açığa Çıkarın" (32 chars) to "Veri Değerinizi Keşfedin" (24 chars) so the button width matches the EN version

## Test plan

- [x] `npm run build` — 63 pages, 0 warnings, 0 errors
- [x] Browser console clean on Home, About, Careers, Clients, Insights, Partners, Solutions, Data Platforms, Academy, Contact
- [x] Verified card h3 sizes via DevTools inspect: all card variants now render at 18.4px / 700 (1.15rem / `--fw-card-title`)
- [x] Verified color tokens applied: `.success-card h3` → `rgb(11, 18, 32)` (`--clr-light-text`), AboutPage timeline year → `rgb(0, 200, 150)` (brand teal)
- [x] TR ROI button width: 220px (EN: 240px) — no more visual overflow
- [ ] Visual review on staging after merge

## Out of scope

`Header.astro`, `Footer.astro`, `LanguagePicker.astro`, gamification components and product/UseCase shared components still contain hardcoded hex colors. These need separate review per CLAUDE.md (shared components require explicit approval) and will be addressed in a follow-up branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)