### PR TITLE
fix: feedback round 1 — Türkiye rename + homepage logo grid

### DIFF
--- a/src/components/gamification/EasterEggTerminal.astro
+++ b/src/components/gamification/EasterEggTerminal.astro
@@ -34,7 +34,7 @@ const TERM_STRINGS = {
       ],
       facts: [
         '  Founded:       2006',
-        '  Headquarters:  Istanbul, Turkey',
+        '  Headquarters:  Istanbul, Türkiye',
         '  Team:          450+ professionals',
         '  Presence:      7 countries',
         '  Academy:       240+ graduates',
@@ -62,7 +62,7 @@ const TERM_STRINGS = {
       ],
       regionsLabel: '  Regions:',
       regions: [
-        '    Turkey (HQ)',
+        '    Türkiye (HQ)',
         '    UAE',
         '    Saudi Arabia',
         '    Pakistan',

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -142,12 +142,12 @@
   "home.globalImpact.label": "Global Presence",
   "home.globalImpact.title": "Global Impact in Data & ",
   "home.globalImpact.titleHighlight": "Artificial Intelligence",
-  "home.globalImpact.sub": "Turkey-based data and AI company delivering enterprise-grade solutions across 20+ countries with successful projects in banking, telecom, public sector and manufacturing.",
+  "home.globalImpact.sub": "Türkiye-based data and AI company delivering enterprise-grade solutions across 20+ countries with successful projects in banking, telecom, public sector and manufacturing.",
   "home.globalImpact.mapAlt": "Global footprint",
   "home.globalImpact.map.seattle": "Seattle, USA",
   "home.globalImpact.map.london": "London, UK",
   "home.globalImpact.map.tirana": "Tirana, Albania",
-  "home.globalImpact.map.turkey": "Turkey",
+  "home.globalImpact.map.turkey": "Türkiye",
   "home.globalImpact.map.riyadh": "Riyadh, Saudi",
   "home.globalImpact.map.dubai": "Dubai, UAE",
   "home.globalImpact.map.islamabad": "Islamabad, Pakistan",
@@ -752,7 +752,7 @@
 
   "contact.info.addressLine1": "Atatürk Mah. Turgut Özal Blv.",
   "contact.info.addressLine2": "Gardenya 1 Plaza · Floor 1",
-  "contact.info.addressLine3": "Ataşehir, Istanbul · Turkey",
+  "contact.info.addressLine3": "Ataşehir, Istanbul · Türkiye",
 
   "contact.why.title": "Why Join Intellica?",
   "contact.why.stat1": "20+ Countries",

--- a/src/page-templates/HomePage.astro
+++ b/src/page-templates/HomePage.astro
@@ -177,30 +177,24 @@ const websiteSchema = {
         </p>
       </div>
       <div class="logo-grid anim-fade-up">
-        <a class="logo-tile logo-tile--lg" aria-label="Ministry of Interior"><img alt="Ministry of Interior" src="/assets/images/logos/InteriorMinistryTR.png" loading="lazy" /></a>
-        <a class="logo-tile logo-tile--lg" aria-label="EGM"><img alt="EGM" src="/assets/images/logos/egm_logo2.png" loading="lazy" /></a>
-        <a class="logo-tile logo-tile--lg" aria-label="SGK"><img alt="SGK" src="/assets/images/logos/SGKLOGOTYPE-RENKLI.svg" loading="lazy" /></a>
-        <a class="logo-tile logo-tile--lg" aria-label="TCDD"><img alt="TCDD" src="/assets/images/logos/TCDD_Taşımacılık_Logo.png" loading="lazy" /></a>
-        <a class="logo-tile" aria-label="Akbank"><img alt="Akbank" src="/assets/images/logos/Akbank_logo.svg" loading="lazy" /></a>
-        <a class="logo-tile" aria-label="Fibabanka"><img alt="Fibabanka" src="/assets/images/logos/Fibabanka.png" loading="lazy" /></a>
-        <a class="logo-tile" aria-label="ING"><img alt="ING" src="/assets/images/logos/ING.png" loading="lazy" /></a>
-        <a class="logo-tile" aria-label="Odeabank"><img alt="Odeabank" src="/assets/images/logos/Odeabank_logo.png" loading="lazy" /></a>
-        <a class="logo-tile" aria-label="TEB"><img alt="TEB" src="/assets/images/logos/TEB_LOGO.png" loading="lazy" /></a>
-        <a class="logo-tile" aria-label="DenizBank"><img alt="DenizBank" src="/assets/images/logos/DenizBank_logo.svg (1).png" loading="lazy" /></a>
-        <a class="logo-tile" aria-label="TBI Bank"><img alt="TBI Bank" src="/assets/images/logos/tbi-bank.png" loading="lazy" /></a>
-        <a class="logo-tile" aria-label="Birbank"><img alt="Birbank" src="/assets/images/logos/birbank..svg" loading="lazy" /></a>
-        <a class="logo-tile" aria-label="Yapı Kredi"><img alt="Yapı Kredi" src="/assets/images/logos/Yapı_kredi_logo.png" loading="lazy" /></a>
         <a class="logo-tile" aria-label="Vodafone"><img alt="Vodafone" src="/assets/images/logos/Vodafone_logo_2017.png" loading="lazy" /></a>
-        <a class="logo-tile" aria-label="Turkcell"><img alt="Turkcell" src="/assets/images/logos/Turkcell_logo.png" loading="lazy" /></a>
-        <a class="logo-tile" aria-label="Turk Telekom"><img alt="Turk Telekom" src="/assets/images/logos/TURKTELEKOM.png" loading="lazy" /></a>
-        <a class="logo-tile" aria-label="Zain"><img alt="Zain" src="/assets/images/logos/ZAINr.png" loading="lazy" /></a>
+        <a class="logo-tile" aria-label="TBI Bank"><img alt="TBI Bank" src="/assets/images/logos/tbi-bank.png" loading="lazy" /></a>
         <a class="logo-tile" aria-label="T-Mobile"><img alt="T-Mobile" src="/assets/images/logos/TMOBILE.png" loading="lazy" /></a>
-        <a class="logo-tile" aria-label="Boyner"><img alt="Boyner" src="/assets/images/logos/Boyner_Logo.jpg" loading="lazy" /></a>
-        <a class="logo-tile" aria-label="LC Waikiki"><img alt="LC Waikiki" src="/assets/images/logos/lcw.png" loading="lazy" /></a>
+        <a class="logo-tile" aria-label="ING"><img alt="ING" src="/assets/images/logos/ING.png" loading="lazy" /></a>
+        <a class="logo-tile" aria-label="Zain"><img alt="Zain" src="/assets/images/logos/ZAINr.png" loading="lazy" /></a>
+        <a class="logo-tile" aria-label="DenizBank"><img alt="DenizBank" src="/assets/images/logos/DenizBank_logo.svg (1).png" loading="lazy" /></a>
+        <a class="logo-tile" aria-label="Turkcell"><img alt="Turkcell" src="/assets/images/logos/Turkcell_logo.png" loading="lazy" /></a>
+        <a class="logo-tile" aria-label="Akbank"><img alt="Akbank" src="/assets/images/logos/Akbank_logo.svg" loading="lazy" /></a>
+        <a class="logo-tile" aria-label="Turk Telekom"><img alt="Turk Telekom" src="/assets/images/logos/TURKTELEKOM.png" loading="lazy" /></a>
+        <a class="logo-tile" aria-label="Yapı Kredi"><img alt="Yapı Kredi" src="/assets/images/logos/Yapı_kredi_logo.png" loading="lazy" /></a>
+        <a class="logo-tile" aria-label="Birbank"><img alt="Birbank" src="/assets/images/logos/birbank..svg" loading="lazy" /></a>
+        <a class="logo-tile" aria-label="TEB"><img alt="TEB" src="/assets/images/logos/TEB_LOGO.png" loading="lazy" /></a>
         <a class="logo-tile" aria-label="Allianz"><img alt="Allianz" src="/assets/images/logos/Allianz.svg.png" loading="lazy" /></a>
         <a class="logo-tile" aria-label="Anadolu Sigorta"><img alt="Anadolu Sigorta" src="/assets/images/logos/Anadolu_Sigorta_logo.svg" loading="lazy" /></a>
-        <a class="logo-tile" aria-label="Hopi"><img alt="Hopi" src="/assets/images/logos/hopi.png" loading="lazy" /></a>
-        <a class="logo-tile" aria-label="Erciyes Anadolu Holding"><img alt="Erciyes Anadolu Holding" src="/assets/images/logos/Erciyes_Anadolu_Holding_logo.svg" loading="lazy" /></a>
+        <a class="logo-tile" aria-label="Fibabanka"><img alt="Fibabanka" src="/assets/images/logos/Fibabanka.png" loading="lazy" /></a>
+        <a class="logo-tile" aria-label="Odeabank"><img alt="Odeabank" src="/assets/images/logos/Odeabank_logo.png" loading="lazy" /></a>
+        <a class="logo-tile" aria-label="Boyner"><img alt="Boyner" src="/assets/images/logos/Boyner_Logo.jpg" loading="lazy" /></a>
+        <a class="logo-tile" aria-label="LC Waikiki"><img alt="LC Waikiki" src="/assets/images/logos/lcw.png" loading="lazy" /></a>
       </div>
       <div class="text-center anim-fade-up" style="margin-top: 48px;">
         <a href={tp('/clients')} class="btn btn-primary btn-pill btn-lg">{t('home.trustedClients.viewAll')}</a>
@@ -976,7 +970,10 @@ const websiteSchema = {
 
 
 /* Specific logo adjustments */
-img[alt="Hopi"] {
+img[alt="LC Waikiki"] {
+  transform: scale(0.8);
+}
+img[alt="Yapı Kredi"] {
   transform: scale(1.4);
 }
 


### PR DESCRIPTION
## Summary

User feedback round 1 fixes:

- **Türkiye rename**: homepage world map label, Global Impact subtitle, contact address, and Easter Egg terminal facts now use the official "Türkiye" spelling. JSON-LD `areaServed` in Layout.astro deliberately kept as "Turkey" for search-engine schema compatibility.
- **Homepage logo grid**: removed 4 government institution logos (Ministry of Interior, EGM, SGK, TCDD) plus Hopi and Erciyes Anadolu Holding. These remain on `/clients`. Reordered the remaining 18 logos so foreign banks/telcos (Vodafone, TBI Bank, T-Mobile, ING, Zain) lead, with Turkish flagship banks/telcos in the middle and insurance/retail at the bottom. Also dropped the unused `logo-tile--lg` modifier.
- **Logo sizing**: LC Waikiki scaled to `0.8` (its image proportions made it visually heavier than the others), Yapı Kredi scaled to `1.4` (its source file has padding around the wordmark). Obsolete Hopi scale rule removed.

## Test plan

- [x] `npm run build` — 63 pages, 0 warnings, 0 errors
- [x] DOM verification: 18 logos rendered in correct order; LCW transform `matrix(0.8, 0, 0, 0.8, 0, 0)`; Yapı Kredi transform `matrix(1.4, 0, 0, 1.4, 0, 0)`
- [x] Homepage map label confirmed as "Türkiye" via DOM query
- [x] Contact address confirmed as "Ataşehir, Istanbul · Türkiye"
- [x] Console clean on home and contact

🤖 Generated with [Claude Code](https://claude.com/claude-code)